### PR TITLE
Externalize the Configuration 

### DIFF
--- a/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
+++ b/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
@@ -58,6 +58,13 @@ public abstract class AbstractFbBot implements FbBotDefinition {
 	 * The logger.
 	 */
 	private static final Logger logger = LoggerFactory.getLogger(AbstractFbBot.class);
+	private static final String FB_BOTMILL_PROPERTIES_FILENAME = "botmill.properties";
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROP = "fb.page.token";
+	private static final String FB_BOTMILL_VALIDATION_TOKEN_PROP = "fb.validation.token";
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROPERTY = "PAGE_TOKEN";
+	private static final String FB_BOTMILL_WEBHOOK_TOKEN_PROPERTY = "VALIDATION_TOKEN";
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROP_PHOLDER = "<PAGE_TOKEN>";
+	private static final String FB_BOTMILL_VALIDATION_TOKEN_PROP_PHOLDER = "<VALIDATION_TOKEN>";
 
 	/**
 	 * The {@link FbBot} object handled by this class.
@@ -139,19 +146,19 @@ public abstract class AbstractFbBot implements FbBotDefinition {
 	 * This builds the config from the classpath botmill.properties.
 	 */
 	private void buildFbBotMillConfig() throws FbBotMillMissingConfigurationException {
-		Properties prop = PropertiesUtil.load("botmill.properties");
+		Properties prop = PropertiesUtil.load(FB_BOTMILL_PROPERTIES_FILENAME);
 		
 		String fbPageToken;
 		String fbValidationToken;
 		
 		try {
-			fbPageToken = ((prop.getProperty("fb.page.token").equals("")
-					|| prop.getProperty("fb.page.token").indexOf("<PAGE_TOKEN>") == 0) ? System.getenv("PAGE_TOKEN")
-							: prop.getProperty("fb.page.token"));
+			fbPageToken = ((prop.getProperty(FB_BOTMILL_PAGE_TOKEN_PROP).equals("")
+					|| prop.getProperty(FB_BOTMILL_PAGE_TOKEN_PROP).indexOf(FB_BOTMILL_PAGE_TOKEN_PROP_PHOLDER) == 0) ? System.getenv(FB_BOTMILL_PAGE_TOKEN_PROPERTY)
+							: prop.getProperty(FB_BOTMILL_PAGE_TOKEN_PROP));
 
-			fbValidationToken = ((prop.getProperty("fb.validation.token").equals("")
-					|| prop.getProperty("fb.validation.token").indexOf("<VALIDATION_TOKEN>") == 0) ? System.getenv("VALIDATION_TOKEN")
-							: prop.getProperty("fb.validation.token"));
+			fbValidationToken = ((prop.getProperty(FB_BOTMILL_VALIDATION_TOKEN_PROP).equals("")
+					|| prop.getProperty(FB_BOTMILL_VALIDATION_TOKEN_PROP).indexOf(FB_BOTMILL_VALIDATION_TOKEN_PROP_PHOLDER) == 0) ? System.getenv(FB_BOTMILL_WEBHOOK_TOKEN_PROPERTY)
+							: prop.getProperty(FB_BOTMILL_VALIDATION_TOKEN_PROP));
 		} catch (Exception e) {
 			logger.error("Make sure that fb.page.token and fb.validation.token properties exist on the property file");
 			return;
@@ -162,10 +169,8 @@ public abstract class AbstractFbBot implements FbBotDefinition {
 					+ "Please check if the appropriate property values are configured correctly.");
 		}
 
-
 		// Everything goes well, initialize the setup.
-		FbBotMillContext.getInstance().setup(fbPageToken,
-				fbValidationToken);
+		FbBotMillContext.getInstance().setup(fbPageToken,fbValidationToken);
 	}
 
 	/**

--- a/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
+++ b/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
@@ -146,11 +146,11 @@ public abstract class AbstractFbBot implements FbBotDefinition {
 		
 		try {
 			fbPageToken = ((prop.getProperty("fb.page.token").equals("")
-					|| prop.getProperty("fb.page.token").indexOf("<PAGE_TOKEN>") == 0) ? System.getProperty("PAGE_TOKEN")
+					|| prop.getProperty("fb.page.token").indexOf("<PAGE_TOKEN>") == 0) ? System.getenv("PAGE_TOKEN")
 							: prop.getProperty("fb.page.token"));
 
 			fbValidationToken = ((prop.getProperty("fb.validation.token").equals("")
-					|| prop.getProperty("fb.validation.token").indexOf("<VALIDATION_TOKEN>") == 0) ? System.getProperty("VALIDATION_TOKEN")
+					|| prop.getProperty("fb.validation.token").indexOf("<VALIDATION_TOKEN>") == 0) ? System.getenv("VALIDATION_TOKEN")
 							: prop.getProperty("fb.validation.token"));
 		} catch (Exception e) {
 			logger.error("Make sure that fb.page.token and fb.validation.token properties exist on the property file");

--- a/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
+++ b/src/main/java/co/aurasphere/botmill/fb/AbstractFbBot.java
@@ -165,7 +165,7 @@ public abstract class AbstractFbBot implements FbBotDefinition {
 		}
 
 		if (fbPageToken == null || fbValidationToken == null) {
-			throw new FbBotMillMissingConfigurationException("FB-BotMill Configuration is missing (botmill.properties). "
+			logger.error("FB-BotMill Configuration is missing (botmill.properties). "
 					+ "Please check if the appropriate property values are configured correctly.");
 		}
 

--- a/src/main/java/co/aurasphere/botmill/fb/FbBot.java
+++ b/src/main/java/co/aurasphere/botmill/fb/FbBot.java
@@ -25,7 +25,6 @@ package co.aurasphere.botmill.fb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import co.aurasphere.botmill.fb.actionframe.ActionFrame;
 import co.aurasphere.botmill.fb.autoreply.AutoReply;
 import co.aurasphere.botmill.fb.event.FbBotMillEvent;

--- a/src/main/java/co/aurasphere/botmill/fb/exception/FbBotMillMissingConfigurationException.java
+++ b/src/main/java/co/aurasphere/botmill/fb/exception/FbBotMillMissingConfigurationException.java
@@ -21,32 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package co.aurasphere.botmill.fb.demo;
-
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.MOCK_FACEBOOK_ID;
-
-import co.aurasphere.botmill.fb.demo.behavior.AnnotatedTemplatedBehaviour;
-import co.aurasphere.botmill.fb.demo.behavior.TemplateBehavior;
-import co.aurasphere.botmill.fb.support.FbBotMillMockMediator;
+package co.aurasphere.botmill.fb.exception;
 
 /**
- * The Class FbBotMillDemo.
+ * The Class FbBotMillControllerEventMisMatchException.
+ * 
+ * @author Alvin P. Reyes
  */
-public class FbBotMillDemo {
+public class FbBotMillMissingConfigurationException extends Exception {
+	/**
+	 * The serial version UID.
+	 */
+	private static final long serialVersionUID = 1L;
 
 	/**
-	 * The main method.
+	 * Instantiates a new FbBot illegal attachment exception.
 	 *
-	 * @param args
-	 *            the arguments
+	 * @param message
+	 *            the message.
 	 */
-	public static void main(String[] args) {
+	public FbBotMillMissingConfigurationException(String message) {
+		super(message);
+	}
 
-		// Instantiating the testing framework and starting the interactive
-		// test.
-		FbBotMillMockMediator mediator = FbBotMillMockMediator.getInstance(MOCK_FACEBOOK_ID,
-				TemplateBehavior.class);
-		mediator.interactiveTest();
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Throwable#toString()
+	 */
+	@Override
+	public String toString() {
+		return "FbBotMillControllerEventMisMatchException []";
 	}
 
 }

--- a/src/main/java/co/aurasphere/botmill/fb/internal/util/properties/PropertiesUtil.java
+++ b/src/main/java/co/aurasphere/botmill/fb/internal/util/properties/PropertiesUtil.java
@@ -21,32 +21,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package co.aurasphere.botmill.fb.demo;
+package co.aurasphere.botmill.fb.internal.util.properties;
 
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.MOCK_FACEBOOK_ID;
+import java.util.Properties;
 
-import co.aurasphere.botmill.fb.demo.behavior.AnnotatedTemplatedBehaviour;
-import co.aurasphere.botmill.fb.demo.behavior.TemplateBehavior;
-import co.aurasphere.botmill.fb.support.FbBotMillMockMediator;
+import co.aurasphere.botmill.fb.exception.FbBotMillMissingConfigurationException;
 
 /**
- * The Class FbBotMillDemo.
+ * The Class PropertiesUtil.
+ * 
+ * @author Alvin P. Reyes
  */
-public class FbBotMillDemo {
+public class PropertiesUtil {
 
+	/** The properties. */
+	private static Properties properties = new Properties();
+	
 	/**
-	 * The main method.
+	 * Load the property values from the properties file into the class loader. 
 	 *
-	 * @param args
-	 *            the arguments
+	 * @param propertiesPath the properties path. 
+	 * @return the properties
+	 * @throws FbBotMillMissingConfigurationException the fb bot mill missing configuration exception
 	 */
-	public static void main(String[] args) {
-
-		// Instantiating the testing framework and starting the interactive
-		// test.
-		FbBotMillMockMediator mediator = FbBotMillMockMediator.getInstance(MOCK_FACEBOOK_ID,
-				TemplateBehavior.class);
-		mediator.interactiveTest();
-	}
-
+	public static Properties load(String propertiesPath) throws FbBotMillMissingConfigurationException {
+		try {
+			properties.load(PropertiesUtil.class.getClassLoader().getResourceAsStream(propertiesPath));
+		} catch (Exception e) {
+			throw new FbBotMillMissingConfigurationException("Missing configuration file (botmill.properties)");
+		}
+		return properties;
+	}	
 }

--- a/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillController.java
+++ b/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillController.java
@@ -32,6 +32,7 @@ import java.lang.annotation.Target;
 
 import co.aurasphere.botmill.fb.event.FbBotMillEventType;
 
+// TODO: Auto-generated Javadoc
 /**
  * The Interface BotMillController.
  * 
@@ -105,4 +106,11 @@ public @interface BotMillController {
 	 * @return true, if successful
 	 */
 	boolean caseSensitive() default false;
+
+	/**
+	 * Meta.
+	 *
+	 * @return the string
+	 */
+	String meta() default ""; // random text to indicate the purpose.
 }

--- a/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillController.java
+++ b/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillController.java
@@ -32,7 +32,6 @@ import java.lang.annotation.Target;
 
 import co.aurasphere.botmill.fb.event.FbBotMillEventType;
 
-// TODO: Auto-generated Javadoc
 /**
  * The Interface BotMillController.
  * 

--- a/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillInit.java
+++ b/src/main/java/co/aurasphere/botmill/fb/model/annotation/BotMillInit.java
@@ -21,32 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package co.aurasphere.botmill.fb.demo;
+package co.aurasphere.botmill.fb.model.annotation;
 
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.MOCK_FACEBOOK_ID;
-
-import co.aurasphere.botmill.fb.demo.behavior.AnnotatedTemplatedBehaviour;
-import co.aurasphere.botmill.fb.demo.behavior.TemplateBehavior;
-import co.aurasphere.botmill.fb.support.FbBotMillMockMediator;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * The Class FbBotMillDemo.
+ * The Interface BotMillController.
+ * 
+ * @author Alvin P. Reyes
  */
-public class FbBotMillDemo {
-
+@Documented
+@Target(ElementType.METHOD)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BotMillInit {
+	
 	/**
-	 * The main method.
+	 * Meta.
 	 *
-	 * @param args
-	 *            the arguments
+	 * @return the string
 	 */
-	public static void main(String[] args) {
-
-		// Instantiating the testing framework and starting the interactive
-		// test.
-		FbBotMillMockMediator mediator = FbBotMillMockMediator.getInstance(MOCK_FACEBOOK_ID,
-				TemplateBehavior.class);
-		mediator.interactiveTest();
-	}
-
+	String meta() default ""; // random text to indicate the purpose.
 }

--- a/src/main/java/co/aurasphere/botmill/fb/threadsettings/FbBotMillThreadSettingsConfiguration.java
+++ b/src/main/java/co/aurasphere/botmill/fb/threadsettings/FbBotMillThreadSettingsConfiguration.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import co.aurasphere.botmill.fb.FbBotDefinition;
 import co.aurasphere.botmill.fb.internal.util.network.NetworkUtils;
 import co.aurasphere.botmill.fb.model.outcoming.template.button.Button;
+import co.aurasphere.botmill.fb.model.outcoming.template.button.ButtonType;
 import co.aurasphere.botmill.fb.model.outcoming.template.button.BuyButton;
 import co.aurasphere.botmill.fb.model.outcoming.template.button.PaymentSummary;
 import co.aurasphere.botmill.fb.model.outcoming.template.button.PostbackButton;
@@ -124,7 +125,7 @@ public class FbBotMillThreadSettingsConfiguration {
 			logger.error("FbBotMill validation error: Get Started Button payload can't be null or empty!");
 			return;
 		}
-		Button button = new PostbackButton(null, null, payload);
+		Button button = new PostbackButton(null, ButtonType.POSTBACK, payload);
 		List<Button> buttonList = new ArrayList<Button>();
 		buttonList.add(button);
 		CallToActionsRequest request = new CallToActionsRequest(

--- a/src/main/resources/botmill.properties
+++ b/src/main/resources/botmill.properties
@@ -1,0 +1,2 @@
+fb.page.token=<PAGE_TOKEN>
+fb.validation.token=<VALIDATION_TOKEN>

--- a/src/main/resources/botmill.properties
+++ b/src/main/resources/botmill.properties
@@ -1,2 +1,6 @@
+# Fb-BotMill 
+# Make sure to put the proper page and validation token in this property file before
+# running.
+
 fb.page.token=<PAGE_TOKEN>
 fb.validation.token=<VALIDATION_TOKEN>

--- a/src/test/java/co/aurasphere/botmill/fb/demo/FbBotMillDemo.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/FbBotMillDemo.java
@@ -23,9 +23,8 @@
  */
 package co.aurasphere.botmill.fb.demo;
 
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.MOCK_FACEBOOK_ID;
+import static co.aurasphere.botmill.fb.demo.FbBotMillDemoData.*;
 
-import co.aurasphere.botmill.fb.demo.behavior.AnnotatedTemplatedBehaviour;
 import co.aurasphere.botmill.fb.demo.behavior.TemplateBehavior;
 import co.aurasphere.botmill.fb.support.FbBotMillMockMediator;
 
@@ -44,7 +43,7 @@ public class FbBotMillDemo {
 
 		// Instantiating the testing framework and starting the interactive
 		// test.
-		FbBotMillMockMediator mediator = FbBotMillMockMediator.getInstance(MOCK_FACEBOOK_ID,
+		FbBotMillMockMediator mediator = FbBotMillMockMediator.getInstance(getFacebookMockId(),
 				TemplateBehavior.class);
 		mediator.interactiveTest();
 	}

--- a/src/test/java/co/aurasphere/botmill/fb/demo/FbBotMillDemoData.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/FbBotMillDemoData.java
@@ -1,0 +1,137 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 BotMill.io
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package co.aurasphere.botmill.fb.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import co.aurasphere.botmill.fb.exception.FbBotMillMissingConfigurationException;
+import co.aurasphere.botmill.fb.internal.util.properties.PropertiesUtil;
+
+// TODO: Auto-generated Javadoc
+/**
+ * Put your data here to test the FBotMill Framework framework.
+ * 
+ * @author Alvin P. Reyes
+ */
+public class FbBotMillDemoData {
+
+	/** The Constant logger. */
+	private static final Logger logger = LoggerFactory.getLogger(FbBotMillDemoData.class);
+	
+	/** The Constant FB_BOTMILL_PROPERTIES_FILENAME. */
+	//	Properties.
+	private static final String FB_BOTMILL_PROPERTIES_FILENAME = "botmill.properties";
+	
+	/** The Constant FB_BOTMILL_MOCK_ID_PROP. */
+	private static final String FB_BOTMILL_MOCK_ID_PROP = "fb.mock.id";
+	
+	/** The Constant FB_BOTMILL_PAGE_TOKEN_PROP. */
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROP = "fb.page.token";
+	
+	/** The Constant FB_BOTMILL_VALIDATION_TOKEN_PROP. */
+	private static final String FB_BOTMILL_VALIDATION_TOKEN_PROP = "fb.validation.token";
+	
+	/** The Constant FB_BOTMILL_MOCK_ID_PROP_PHOLDER. */
+	//	Property placeholder
+	private static final String FB_BOTMILL_MOCK_ID_PROP_PHOLDER = "<MOCK_FACEBOOK_ID>";
+	
+	/** The Constant FB_BOTMILL_PAGE_TOKEN_PROP_PHOLDER. */
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROP_PHOLDER = "<PAGE_TOKEN>";
+	
+	/** The Constant FB_BOTMILL_VALIDATION_TOKEN_PROP_PHOLDER. */
+	private static final String FB_BOTMILL_VALIDATION_TOKEN_PROP_PHOLDER = "<VALIDATION_TOKEN>";
+	
+	/** The Constant FB_BOTMILL_MOCK_ID_PROPERTY. */
+	//	Environment variable
+	private static final String FB_BOTMILL_MOCK_ID_PROPERTY = "MOCK_FACEBOOK_ID";
+	
+	/** The Constant FB_BOTMILL_PAGE_TOKEN_PROPERTY. */
+	private static final String FB_BOTMILL_PAGE_TOKEN_PROPERTY = "PAGE_TOKEN";
+	
+	/** The Constant FB_BOTMILL_WEBHOOK_TOKEN_PROPERTY. */
+	private static final String FB_BOTMILL_WEBHOOK_TOKEN_PROPERTY = "VALIDATION_TOKEN";
+
+	/**
+	 *  The method getFacebookMockId.
+	 *
+	 * @return the facebook mock id
+	 */
+	// 	Please check our wiki https://github.com/BotMill/fb-botmill/wiki/Unit-Testing 
+	//	on how to get the mock_facebook_id
+	public static String getFacebookMockId() {
+		try {
+			String mockId = PropertiesUtil.load(FB_BOTMILL_PROPERTIES_FILENAME).getProperty(FB_BOTMILL_MOCK_ID_PROP);
+			logger.info(mockId);
+			if(mockId.equals("") || mockId.contains(FB_BOTMILL_MOCK_ID_PROP_PHOLDER)) {
+				return System.getProperty(FB_BOTMILL_MOCK_ID_PROPERTY);
+			}
+			return mockId;
+		} catch (FbBotMillMissingConfigurationException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * Gets the fb page token.
+	 *
+	 * @return the fb page token
+	 */
+	public static String getFbPageToken() {
+		try {
+			String pageToken = PropertiesUtil.load(FB_BOTMILL_PROPERTIES_FILENAME).getProperty(FB_BOTMILL_PAGE_TOKEN_PROP);
+			logger.info(pageToken);
+			if(pageToken.equals("") || pageToken.contains(FB_BOTMILL_PAGE_TOKEN_PROP_PHOLDER)) {
+				return System.getProperty(FB_BOTMILL_PAGE_TOKEN_PROPERTY);
+			}
+			return pageToken;
+		} catch (FbBotMillMissingConfigurationException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * Gets the fb validation token.
+	 *
+	 * @return the fb validation token
+	 */
+	public static String getFbValidationToken() {
+		try {
+			String validationToken = PropertiesUtil.load(FB_BOTMILL_PROPERTIES_FILENAME).getProperty(FB_BOTMILL_VALIDATION_TOKEN_PROP);
+			logger.info(validationToken);
+			if(validationToken.equals("") || validationToken.contains(FB_BOTMILL_VALIDATION_TOKEN_PROP_PHOLDER)) {
+				return System.getProperty(FB_BOTMILL_WEBHOOK_TOKEN_PROPERTY);
+			}
+			return validationToken;
+		} catch (FbBotMillMissingConfigurationException e) {
+			e.printStackTrace();
+		}
+		
+		return null;
+	}
+
+}

--- a/src/test/java/co/aurasphere/botmill/fb/demo/behavior/AnnotatedTemplatedBehaviour.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/behavior/AnnotatedTemplatedBehaviour.java
@@ -24,26 +24,46 @@
 package co.aurasphere.botmill.fb.demo.behavior;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
 import co.aurasphere.botmill.fb.AbstractFbBot;
 import co.aurasphere.botmill.fb.autoreply.AutoReply;
 import co.aurasphere.botmill.fb.autoreply.MessageAutoReply;
 import co.aurasphere.botmill.fb.event.FbBotMillEventType;
 import co.aurasphere.botmill.fb.model.annotation.BotMillController;
+import co.aurasphere.botmill.fb.model.annotation.BotMillInit;
 import co.aurasphere.botmill.fb.model.incoming.MessageEnvelope;
 import co.aurasphere.botmill.fb.model.outcoming.FbBotMillResponse;
 import co.aurasphere.botmill.fb.model.outcoming.factory.ButtonFactory;
 import co.aurasphere.botmill.fb.model.outcoming.factory.ReplyFactory;
+import co.aurasphere.botmill.fb.model.outcoming.template.button.Button;
+import co.aurasphere.botmill.fb.threadsettings.FbBotMillThreadSettingsConfiguration;
+
 
 /**
  * The Class TemplateBehavior.
  */
 public class AnnotatedTemplatedBehaviour extends AbstractFbBot {
 	
+	@BotMillInit
+	public void initialize() {
+
+		List<Button> buttons = new ArrayList<Button>();
+		buttons.add(ButtonFactory.createPostbackButton("Postback Button", "PPB Payload"));
+		buttons.add(ButtonFactory.createUrlButton("URL Button", "http://www.aurasphere.co"));
+
+		// Sets the thread settings.
+		FbBotMillThreadSettingsConfiguration.setGreetingMessage("Hi, welcome to FbBotMill!");
+		FbBotMillThreadSettingsConfiguration.setGetStartedButton("Get Started Button Payload");
+		FbBotMillThreadSettingsConfiguration.setPersistentMenu(buttons);
+	}
+	
 	@BotMillController(eventType=FbBotMillEventType.MESSAGE, text="text message", caseSensitive = true)
 	public void replyText() {
 		reply(new MessageAutoReply("simple text message"));
 	}
-	
+
 	@BotMillController(eventType=FbBotMillEventType.MESSAGE, text="button template", caseSensitive = false)
 	public void replyWithButtonTemplate() {
 		reply(new AutoReply() {
@@ -56,7 +76,7 @@ public class AnnotatedTemplatedBehaviour extends AbstractFbBot {
 			}
 		});
 	}
-	
+
 	@BotMillController(eventType=FbBotMillEventType.MESSAGE, text="list template", caseSensitive = false)
 	public void replyWithLisTemplate() {
 		reply(new AutoReply() {
@@ -100,7 +120,6 @@ public class AnnotatedTemplatedBehaviour extends AbstractFbBot {
 	@BotMillController(eventType=FbBotMillEventType.MESSAGE, text="quick replies", caseSensitive = false)
 	public void replywithQuickReplies() {
 		reply(new AutoReply() {
-
 			@Override
 			public FbBotMillResponse createResponse(MessageEnvelope envelope) {
 				return ReplyFactory.addTextMessageOnly("Text message with quick replies")

--- a/src/test/java/co/aurasphere/botmill/fb/demo/threadsettings/ThreadSettingsDemoConfiguration.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/threadsettings/ThreadSettingsDemoConfiguration.java
@@ -30,7 +30,7 @@ import co.aurasphere.botmill.fb.FbBotMillContext;
 import co.aurasphere.botmill.fb.model.outcoming.factory.ButtonFactory;
 import co.aurasphere.botmill.fb.model.outcoming.template.button.Button;
 import co.aurasphere.botmill.fb.threadsettings.FbBotMillThreadSettingsConfiguration;
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.*;
+import static co.aurasphere.botmill.fb.demo.FbBotMillDemoData.*;
 
 /**
  * Demo of configuring the Thread Settings.
@@ -49,7 +49,7 @@ public class ThreadSettingsDemoConfiguration {
 	 */
 	public static void main(String[] args) {
 		// Configuration.
-		FbBotMillContext.getInstance().setup(PAGE_TOKEN, VALIDATION_TOKEN);
+		FbBotMillContext.getInstance().setup(getFbPageToken(), getFbValidationToken());
 
 		// Creates a list of persistent buttons.
 		List<Button> buttons = new ArrayList<Button>();

--- a/src/test/java/co/aurasphere/botmill/fb/demo/threadsettings/ThreadSettingsDemoReset.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/threadsettings/ThreadSettingsDemoReset.java
@@ -23,7 +23,7 @@
  */
 package co.aurasphere.botmill.fb.demo.threadsettings;
 
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.*;
+import static co.aurasphere.botmill.fb.demo.FbBotMillDemoData.*;
 
 import co.aurasphere.botmill.fb.FbBotMillContext;
 import co.aurasphere.botmill.fb.threadsettings.FbBotMillThreadSettingsConfiguration;
@@ -44,7 +44,7 @@ public class ThreadSettingsDemoReset {
 	 */
 	public static void main(String[] args) {
 		// Configuration.
-		FbBotMillContext.getInstance().setup(PAGE_TOKEN, VALIDATION_TOKEN);
+		FbBotMillContext.getInstance().setup(getFbPageToken(), getFbValidationToken());
 
 		FbBotMillThreadSettingsConfiguration.deleteGetStartedButton();
 		FbBotMillThreadSettingsConfiguration.deletePersistentMenu();

--- a/src/test/java/co/aurasphere/botmill/fb/demo/userprofile/UserProfileRetrieverDemo.java
+++ b/src/test/java/co/aurasphere/botmill/fb/demo/userprofile/UserProfileRetrieverDemo.java
@@ -23,9 +23,7 @@
  */
 package co.aurasphere.botmill.fb.demo.userprofile;
 
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.MOCK_FACEBOOK_ID;
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.PAGE_TOKEN;
-import static co.aurasphere.botmill.fb.demo.FbBotMillDemoConstants.VALIDATION_TOKEN;
+import static co.aurasphere.botmill.fb.demo.FbBotMillDemoData.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +47,8 @@ public class UserProfileRetrieverDemo {
 	 *            the arguments
 	 */
 	public static void main(String[] args) {
-		FbBotMillContext.getInstance().setup(PAGE_TOKEN, VALIDATION_TOKEN);
-		FacebookUserProfile user = FbBotMillUserProfileRetriever.getUser(MOCK_FACEBOOK_ID);
+		FbBotMillContext.getInstance().setup(getFbPageToken(), getFbValidationToken());
+		FacebookUserProfile user = FbBotMillUserProfileRetriever.getUser(getFacebookMockId());
 		logger.info("----------- Retrieved user -----------");
 		logger.info("Name: " + user.getFirstName());
 		logger.info("Surname: " + user.getLastName());

--- a/src/test/resources/botmill.properties
+++ b/src/test/resources/botmill.properties
@@ -1,2 +1,8 @@
+# Fb-BotMill 
+# Make sure to put the proper page and validation token in this property file before
+# running.
 fb.page.token=<PAGE_TOKEN>
 fb.validation.token=<VALIDATION_TOKEN>
+
+# for testing only
+fb.mock.id=<MOCK_FACEBOOK_ID>

--- a/src/test/resources/botmill.properties
+++ b/src/test/resources/botmill.properties
@@ -1,0 +1,2 @@
+fb.page.token=<PAGE_TOKEN>
+fb.validation.token=<VALIDATION_TOKEN>


### PR DESCRIPTION
Resolved/Fixed #59 and #62

- Externalize the configuration for fb-botmill by introducing a properties loader and botmill.properties
- Fixed #62 to ensure that the get started button uses the correct button type upon initialization.